### PR TITLE
icap: Add nodePorts options

### DIFF
--- a/helm_charts/icap/templates/services-template.yml
+++ b/helm_charts/icap/templates/services-template.yml
@@ -17,26 +17,41 @@ spec:
     - name: "rest-port"
       port: {{ $component.ports.rest }}
       targetPort: {{ $component.ports.rest }}
+      {{- if and (or (eq $component.service_type "NodePort") (eq $component.service_type "LoadBalancer")) (and $component.nodePorts $component.nodePorts.rest) }}
+      nodePort: {{ $component.nodePorts.rest }}
+      {{- end }}
 {{- end }}
 {{- if $component.ports.icap }}
     - name: "icap-port"
       port: {{ $component.ports.icap }}
       targetPort: {{ $component.ports.icap }}
+      {{- if and (or (eq $component.service_type "NodePort") (eq $component.service_type "LoadBalancer")) (and $component.nodePorts $component.nodePorts.icap) }}
+      nodePort: {{ $component.nodePorts.icap }}
+      {{- end }}
 {{- end }}
 {{- if $component.ports.icaps }}
     - name: "icaps-port"
       port: {{ $component.ports.icaps }}
       targetPort: {{ $component.ports.icaps }}
+      {{- if and (or (eq $component.service_type "NodePort") (eq $component.service_type "LoadBalancer")) (and $component.nodePorts $component.nodePorts.icaps) }}
+      nodePort: {{ $component.nodePorts.icaps }}
+      {{- end }}
 {{- end }}
 {{- if $component.ports.nginx }}
     - name: "nginx-port"
       port: {{ $component.ports.nginx }}
       targetPort: {{ $component.ports.nginx }}
+      {{- if and (or (eq $component.service_type "NodePort") (eq $component.service_type "LoadBalancer")) (and $component.nodePorts $component.nodePorts.nginx) }}
+      nodePort: {{ $component.nodePorts.nginx }}
+      {{- end }}
 {{- end }}
 {{- if $component.ports.nginxs }}
     - name: "nginxs-port"
       port: {{ $component.ports.nginxs }}
       targetPort: {{ $component.ports.nginxs }}
+      {{- if and (or (eq $component.service_type "NodePort") (eq $component.service_type "LoadBalancer")) (and $component.nodePorts $component.nodePorts.nginxs) }}
+      nodePort: {{ $component.nodePorts.nginxs }}
+      {{- end }}
 {{- end }}
   {{- if $component.service_type }}
   type: {{ $component.service_type }}

--- a/helm_charts/icap/values.yaml
+++ b/helm_charts/icap/values.yaml
@@ -229,6 +229,12 @@ icap_components:
       icaps: 11344 # ICAPS port to expose for the MD ICAP Server pod
       nginx: 8043  # NGINX port for nginx ingress controller connect
       nginxs: 8443 # NGINX (SSL) port for nginx ingress controller connect
+    # nodePorts:
+    #   rest: 38048   # REST nodePort to expose for the MD ICAP Server pod
+    #   icap: 31344   # ICAP nodePort to expose for the MD ICAP Server pod
+    #   icaps: 31344  # ICAPS nodePort to expose for the MD ICAP Server pod
+    #   nginx: 38043  # NGINX nodePort for nginx ingress controller connect
+    #   nginxs: 38443 # NGINX (SSL) nodePort for nginx ingress controller connect
     database:
       db_mode: "4"                   # Database mode
       db_type: remote                # Database type

--- a/helm_charts/mdicapsrv-README.md
+++ b/helm_charts/mdicapsrv-README.md
@@ -104,6 +104,7 @@ The following table lists the configurable parameters of the Metadefender ICAP c
 | `icap_components.md_icapsrv.tls.nginxs.certKeySecretSubPath` | The key in the Secret has the value containing the certificate private key | `"mdicapsrv-nginxs.key"` |
 | `icap_components.md_icapsrv.tls.nginxs.mountPath` |MD ICAP Server container will mount NGINX Communication certificate to the path | `"/nginxs_cert"` |
 | `icap_components.md_icapsrv.ports.rest` | Default REST port for the MD ICAP Server service | `"8048"` |
+| `icap_components.md_icapsrv.nodePorts.rest` | Default REST nodePort for the MD ICAP Server service | `""` |
 | `icap_components.md_icapsrv.trustCertificate.enabled` | Enable mount certificate to MD ICAP Server and trust it | `"true"` |
 | `icap_components.md_icapsrv.trustCertificate.mountPath` | Set the path for mount certificate server to the container | `"/trust_certs"` |
 | `icap_components.md_icapsrv.trustCertificate.configs.certSecret` | Set the name of the secret contains certificate | `"mdicapsrv-trust-server-cert"` |
@@ -112,6 +113,10 @@ The following table lists the configurable parameters of the Metadefender ICAP c
 | `icap_components.md_icapsrv.ports.icaps` | Default ICAPS port for the MD ICAP Server service | `"11344"` |
 | `icap_components.md_icapsrv.ports.nginx` | Default NGINX communication port | `"8043"` |
 | `icap_components.md_icapsrv.ports.nginxs` | Default NGINX secured communication port | `"8443"` |
+| `icap_components.md_icapsrv.nodePorts.icap` | Default ICAP nodePort for the MD ICAP Server service | `""` |
+| `icap_components.md_icapsrv.nodePorts.icaps` | Default ICAPS nodePort for the MD ICAP Server service | `""` |
+| `icap_components.md_icapsrv.nodePorts.nginx` | Default NGINX communication nodePort | `""` |
+| `icap_components.md_icapsrv.nodePorts.nginxs` | Default NGINX secured communication nodePort | `""` |
 | `icap_components.md_icapsrv.database.db_mode` | Database mode | `"4"` |
 | `icap_components.md_icapsrv.database.db_type` | Database type | `"remote"` |
 | `icap_components.md_icapsrv.database.db_host` | Hostname / entrypoint of the database, this value should be changed any if using an external database service | `"postgres-mdicapsrv"` |


### PR DESCRIPTION
When using service type NodePort, it will be set to a random port by default. It is often useful to be able to set this to a static port, so that any external routing can point to the same port even if the service needs to be reinstalled or installed in a different environment. 

This PR adds this functionality, with some checks to not interfere with existing installations.