### PR TITLE
fix(mdcore): seed TLS cert into 0755 emptyDir so activate_https enables HTTPS

### DIFF
--- a/helm_charts/mdcore/templates/deployments-template.yml
+++ b/helm_charts/mdcore/templates/deployments-template.yml
@@ -95,12 +95,10 @@ spec:
               subPath: {{ $component.mountConfig.subPath }}
             {{ end }}
             {{- if $tls.enabled }}
-            - name: {{ $component.tls.certSecret }}
-              mountPath: {{ $.Values.MDCORE_CERT_PATH }}/mdcore.crt
-              subPath: {{ $component.tls.certSecretSubPath }}
-            - name: {{ $component.tls.certKeySecret }}
-              mountPath: {{ $.Values.MDCORE_CERT_PATH }}/mdcore.key
-              subPath: {{ $component.tls.certKeySecretSubPath }}
+            # Cert dir is seeded by the mdcore-cert-perms initContainer (see below) so the
+            # entrypoint's activate_https finds a 0755 dir + 0755 <name>.crt/<name>.key.
+            - name: mdcore-cert
+              mountPath: {{ $.Values.MDCORE_CERT_PATH }}
             {{ end }}
             {{- if $component.persistentDir }}
             - name: {{ $component.name }}
@@ -120,9 +118,37 @@ spec:
           {{- if $component.sidecars }}
             {{- toYaml $component.sidecars | nindent 8 }}
           {{- end }}
-      {{- if $component.initContainers }}
+      {{- if (or $component.initContainers $tls.enabled) }}
       initContainers:
+        {{- if $tls.enabled }}
+        - name: mdcore-cert-perms
+          {{ if $component.custom_repo -}}
+          image: {{ printf "%s/%s:%s" $.Values.core_docker_repo $component.image $.Values.BRANCH | quote }}
+          {{- else -}}
+          image: {{ $component.image | quote }}
+          {{- end }}
+          imagePullPolicy: {{ $.Values.imagePullPolicy }}
+          command:
+            - sh
+            - -c
+            - >
+              mkdir -p {{ $.Values.MDCORE_CERT_PATH }} &&
+              cp -L /mdcore-cert-src/crt/{{ $component.tls.certSecretSubPath }} {{ $.Values.MDCORE_CERT_PATH }}/mdcore.crt &&
+              cp -L /mdcore-cert-src/key/{{ $component.tls.certKeySecretSubPath }} {{ $.Values.MDCORE_CERT_PATH }}/mdcore.key &&
+              chmod 0755 {{ $.Values.MDCORE_CERT_PATH }} {{ $.Values.MDCORE_CERT_PATH }}/mdcore.crt {{ $.Values.MDCORE_CERT_PATH }}/mdcore.key
+          volumeMounts:
+            - name: {{ $component.tls.certSecret }}
+              mountPath: /mdcore-cert-src/crt
+              readOnly: true
+            - name: {{ $component.tls.certKeySecret }}
+              mountPath: /mdcore-cert-src/key
+              readOnly: true
+            - name: mdcore-cert
+              mountPath: {{ $.Values.MDCORE_CERT_PATH }}
+        {{- end }}
+        {{- if $component.initContainers }}
         {{- toYaml $component.initContainers | nindent 8 }}
+        {{- end }}
       {{- end }}
       restartPolicy: Always
       {{- if $.Values.imagePullSecrets }}
@@ -140,14 +166,18 @@ spec:
             name: {{ $component.mountConfig.configName }}
         {{ end }} 
         {{- if $tls.enabled }}
+        # Secret sources are read by the mdcore-cert-perms initContainer and copied into the
+        # mdcore-cert emptyDir. We do not mount the secrets into the cert dir directly because
+        # subPath mounts ignore defaultMode (files land 0644) and whole-secret tmpfs mounts are
+        # dir mode 1777; the entrypoint's lexicographic "perms < 755" check rejects both.
         - name: {{ $component.tls.certSecret }}
           secret:
             secretName: {{ $component.tls.certSecret }}
-            defaultMode: 0755
         - name: {{ $component.tls.certKeySecret }}
           secret:
             secretName: {{ $component.tls.certKeySecret }}
-            defaultMode: 0755
+        - name: mdcore-cert
+          emptyDir: {}
         {{ end }}
         {{- if $component.persistentDir }}
         {{- if eq $.Values.storage_provisioner "hostPath" }}


### PR DESCRIPTION
### Summary
When `core_components.md-core.tls.enabled=true`, the chart currently mounts the cert and key straight at `MDCORE_CERT_PATH` via `subPath`. Kubernetes ignores `defaultMode` on `subPath` mounts, so the files land as `0644`; a whole-secret mount would instead make the directory a `1777` tmpfs.

The container entrypoint (`activate_https` in `mdcore.sh`) gates HTTPS activation on a **lexicographic** check:
```sh
if [[ $(stat -c "%a" ${crt_file}) < "755" ... ]]; then ... return 1; fi
```
`"0644" < "755"` and `"1777" < "755"` are both true, and the mounts are read-only so its self-heal `chmod` fails. Result: HTTPS is silently skipped ("lacks the necessary permissions") and Core keeps serving plain HTTP on the REST port, even though the cert is present.

### Fix
Seed the cert into a `0755` `emptyDir` via a small `mdcore-cert-perms` initContainer (using the component image), then mount that emptyDir at `MDCORE_CERT_PATH`. The entrypoint then finds a `0755` dir with `0755` `<name>.crt` / `<name>.key` and activates HTTPS.

- No behavioural change when `tls.enabled=false` (verified: template renders identically).
- User-defined `initContainers` are preserved and run after the injected one.
- `helm lint` passes; `helm template` verified with tls on and off.

### Test
```
helm template t helm_charts/mdcore --set core_components.md-core.tls.enabled=true --show-only templates/deployments-template.yml
```
shows the `mdcore-cert-perms` initContainer, the `mdcore-cert` emptyDir, and the cert dir mounted at `MDCORE_CERT_PATH`.